### PR TITLE
Fix some Linux bugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           submodules: recursive
 
       - name: Install Necessary Packages
-        run: sudo apt update && sudo apt install -y cmake build-essential ninja-build
+        run: sudo apt update && sudo apt install -y cmake build-essential ninja-build chrpath
 
       - name: Install GCC
         if: ${{ matrix.compiler == 'gcc' }}
@@ -127,6 +127,20 @@ jobs:
       - name: Build
         working-directory: ${{env.BUILD_DIR}}
         run: cmake --build . --config ${{matrix.build_type}} -t vpkedit -- -j$(nproc)
+
+      - name: Fixup Binaries
+        run: |
+          chmod +x '${{env.BUILD_DIR}}/vpkedit'
+
+          # runpath cleanup for the Qt binaries. These are (mostly) wrong, leading to crashes
+          for f in ${{env.BUILD_DIR}}/*.so*; do
+            echo "Fixing $f..."
+            chrpath -r '$ORIGIN' "$f"
+          done
+          for f in ${{env.BUILD_DIR}}/*/*.so*; do
+            echo "Fixing $f..."
+            chrpath -r '$ORIGIN/..' "$f"
+          done
 
       - name: Upload Standalone
         uses: actions/upload-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,11 +180,13 @@ if(VPKEDIT_BUILD_GUI)
                 "${QT_BASEDIR}/plugins/tls/qschannelbackend${QT_LIB_SUFFIX}.dll"
                 DESTINATION tls)
     elseif(UNIX)
-        install(DIRECTORY
-                "${QT_BASEDIR}/lib/"
-                "${QT_BASEDIR}/plugins/"
-                DESTINATION .
-                FILES_MATCHING PATTERN "*.so*")
+        if (DEFINED QT_BASEDIR)
+            install(DIRECTORY
+                    "${QT_BASEDIR}/lib/"
+                    "${QT_BASEDIR}/plugins/"
+                    DESTINATION .
+                    FILES_MATCHING PATTERN "*.so*")
+        endif()
 
         install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/gui/installer/deb/${PROJECT_NAME}.desktop"
                 DESTINATION "/usr/share/applications/")
@@ -218,7 +220,7 @@ if(VPKEDIT_BUILD_GUI)
 
         configure_file("${QT_BASEDIR}/plugins/tls/qcertonlybackend${QT_LIB_SUFFIX}.dll" "${CMAKE_BINARY_DIR}/tls/qcertonlybackend${QT_LIB_SUFFIX}.dll" COPYONLY)
         configure_file("${QT_BASEDIR}/plugins/tls/qschannelbackend${QT_LIB_SUFFIX}.dll" "${CMAKE_BINARY_DIR}/tls/qschannelbackend${QT_LIB_SUFFIX}.dll" COPYONLY)
-    elseif(UNIX)
+    elseif(UNIX AND DEFINED QT_BASEDIR)
         configure_file("${QT_BASEDIR}/lib/libQt6Core.so.6"    "${CMAKE_BINARY_DIR}/libQt6Core.so.6"    COPYONLY)
         configure_file("${QT_BASEDIR}/lib/libQt6Gui.so.6"     "${CMAKE_BINARY_DIR}/libQt6Gui.so.6"     COPYONLY)
         configure_file("${QT_BASEDIR}/lib/libQt6Widgets.so.6" "${CMAKE_BINARY_DIR}/libQt6Widgets.so.6" COPYONLY)

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -579,7 +579,7 @@ void Window::extractAll(QString saveDir) {
         return;
     }
     saveDir += '/';
-    saveDir += this->vpk->getRealFileName();
+    saveDir += this->vpk->getRealFileName().c_str();
 
     this->extractFilesIf(saveDir, [](const QString&) { return true; });
 }


### PR DESCRIPTION
* Fix up RUNPATHs for the Qt libraries when packaging. These are set to `$ORIGIN/../../lib` by default, which works for the normal Qt install location in /usr/lib, but not for VPKEdit. This is the root cause of #14 
* Fix compile error, probably because of Qt version difference? (I'm running 6.4, I think CI is on 6.5)
* Don't `configure_file` when relying solely on `find_package` for Qt library location. This makes it easier to build from source on Linux

Closes #14 