### PR TITLE
feat: sync entry tree and dir preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 project(vpkedit
         DESCRIPTION "A tool to read, preview, and write to VPK files."
-        VERSION 3.3.5
+        VERSION 3.4.0
         HOMEPAGE_URL "https://github.com/craftablescience/VPKEdit")
 set(PROJECT_NAME_PRETTY "VPKEdit" CACHE STRING "" FORCE)
 set(PROJECT_ORGANIZATION_NAME "craftablescience" CACHE STRING "" FORCE)

--- a/src/gui/EntryContextMenuData.h
+++ b/src/gui/EntryContextMenuData.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <type_traits>
+
+#include <QAction>
+#include <QMenu>
+#include <QStyle>
+
+struct EntryContextMenuData {
+    explicit EntryContextMenuData(bool useRoot, QWidget* parent = nullptr) {
+        this->contextMenuFile = new QMenu(parent);
+        this->extractFileAction = this->contextMenuFile->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract File"));
+        this->contextMenuFile->addSeparator();
+        this->removeFileAction = this->contextMenuFile->addAction(parent->style()->standardIcon(QStyle::SP_TrashIcon), QObject::tr("Remove File"));
+
+        this->contextMenuDir = new QMenu(parent);
+        this->extractDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract Folder"));
+        this->contextMenuDir->addSeparator();
+        this->addFileToDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_FileIcon), QObject::tr("Add File..."));
+        this->removeDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_TrashIcon), QObject::tr("Remove Folder"));
+
+        if (useRoot) {
+            this->contextMenuAll = new QMenu(parent);
+            this->extractAllAction = this->contextMenuAll->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract All"));
+            this->contextMenuAll->addSeparator();
+            this->addFileToRootAction = this->contextMenuAll->addAction(parent->style()->standardIcon(QStyle::SP_FileIcon), QObject::tr("Add File..."));
+        }
+    }
+
+    QMenu* contextMenuFile = nullptr;
+    QAction* extractFileAction = nullptr;
+    QAction* removeFileAction = nullptr;
+
+    QMenu* contextMenuDir = nullptr;
+    QAction* extractDirAction = nullptr;
+    QAction* addFileToDirAction = nullptr;
+    QAction* removeDirAction = nullptr;
+
+    QMenu* contextMenuAll = nullptr;
+    QAction* extractAllAction = nullptr;
+    QAction* addFileToRootAction = nullptr;
+};

--- a/src/gui/EntryContextMenuData.h
+++ b/src/gui/EntryContextMenuData.h
@@ -9,21 +9,24 @@
 struct EntryContextMenuData {
     explicit EntryContextMenuData(bool useRoot, QWidget* parent = nullptr) {
         this->contextMenuFile = new QMenu(parent);
-        this->extractFileAction = this->contextMenuFile->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract File"));
+        this->extractFileAction = this->contextMenuFile->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract File..."));
         this->contextMenuFile->addSeparator();
         this->removeFileAction = this->contextMenuFile->addAction(parent->style()->standardIcon(QStyle::SP_TrashIcon), QObject::tr("Remove File"));
 
         this->contextMenuDir = new QMenu(parent);
-        this->extractDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract Folder"));
+        this->extractDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract Folder..."));
         this->contextMenuDir->addSeparator();
         this->addFileToDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_FileIcon), QObject::tr("Add File..."));
+        this->addDirToDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_DirIcon), QObject::tr("Add Folder..."));
+        this->contextMenuDir->addSeparator();
         this->removeDirAction = this->contextMenuDir->addAction(parent->style()->standardIcon(QStyle::SP_TrashIcon), QObject::tr("Remove Folder"));
 
         if (useRoot) {
             this->contextMenuAll = new QMenu(parent);
-            this->extractAllAction = this->contextMenuAll->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract All"));
+            this->extractAllAction = this->contextMenuAll->addAction(parent->style()->standardIcon(QStyle::SP_DialogSaveButton), QObject::tr("Extract All..."));
             this->contextMenuAll->addSeparator();
             this->addFileToRootAction = this->contextMenuAll->addAction(parent->style()->standardIcon(QStyle::SP_FileIcon), QObject::tr("Add File..."));
+            this->addDirToRootAction = this->contextMenuAll->addAction(parent->style()->standardIcon(QStyle::SP_DirIcon), QObject::tr("Add Folder..."));
         }
     }
 
@@ -34,9 +37,11 @@ struct EntryContextMenuData {
     QMenu* contextMenuDir = nullptr;
     QAction* extractDirAction = nullptr;
     QAction* addFileToDirAction = nullptr;
+    QAction* addDirToDirAction = nullptr;
     QAction* removeDirAction = nullptr;
 
     QMenu* contextMenuAll = nullptr;
     QAction* extractAllAction = nullptr;
     QAction* addFileToRootAction = nullptr;
+    QAction* addDirToRootAction = nullptr;
 };

--- a/src/gui/EntryTree.cpp
+++ b/src/gui/EntryTree.cpp
@@ -65,7 +65,7 @@ EntryTree::EntryTree(Window* window_, QWidget* parent)
         }
     });
 
-    QObject::connect(this, &QTreeWidget::itemClicked, this, &EntryTree::onItemClicked);
+    QObject::connect(this, &QTreeWidget::currentItemChanged, this, &EntryTree::onCurrentItemChanged);
 
     this->clearContents();
 }
@@ -106,7 +106,7 @@ void EntryTree::loadVPK(VPK& vpk, QProgressBar* progressBar, const std::function
 
         // Fire the click manually to show the contents and expand the root
         this->root->setSelected(true);
-        this->onItemClicked(this->root, 0);
+        this->onCurrentItemChanged(this->root);
         this->root->setExpanded(true);
 
         finishCallback();
@@ -122,7 +122,7 @@ void EntryTree::selectSubItem(const QString& name) {
             auto* child = selected->child(i);
             if (child->text(0) == name) {
                 child->setSelected(true);
-                this->onItemClicked(child, 0);
+                this->onCurrentItemChanged(child);
                 child->setExpanded(true);
             }
         }
@@ -180,7 +180,7 @@ void EntryTree::addEntry(const QString& path) {
     this->addNestedEntryComponents(path);
 }
 
-void EntryTree::onItemClicked(QTreeWidgetItem* item, int /*column*/) {
+void EntryTree::onCurrentItemChanged(QTreeWidgetItem* item) {
     if (this->autoExpandDirectories) {
         item->setExpanded(!item->isExpanded());
     }

--- a/src/gui/EntryTree.cpp
+++ b/src/gui/EntryTree.cpp
@@ -30,32 +30,36 @@ EntryTree::EntryTree(Window* window_, QWidget* parent)
                 auto* selectedAllAction = contextMenuData.contextMenuAll->exec(this->mapToGlobal(pos));
 
                 // Handle the selected action
-                if (selectedAllAction == contextMenuData.addFileToRootAction) {
-                    this->window->addFile();
-                } else if (selectedAllAction == contextMenuData.extractAllAction) {
+                if (selectedAllAction == contextMenuData.extractAllAction) {
                     this->window->extractAll();
+                } else if (selectedAllAction == contextMenuData.addFileToRootAction) {
+                    this->window->addFile();
+                } else if (selectedAllAction == contextMenuData.addDirToRootAction) {
+                    this->window->addDir();
                 }
             } else if (selectedItem->childCount() > 0) {
                 // Show the directory context menu at the requested position
                 auto* selectedDirAction = contextMenuData.contextMenuDir->exec(this->mapToGlobal(pos));
 
                 // Handle the selected action
-                if (selectedDirAction == contextMenuData.addFileToDirAction) {
+                if (selectedDirAction == contextMenuData.extractDirAction) {
+                    this->window->extractDir(path);
+                } else if (selectedDirAction == contextMenuData.addFileToDirAction) {
                     this->window->addFile(path);
+                } else if (selectedDirAction == contextMenuData.addDirToDirAction) {
+                    this->window->addDir(path);
                 } else if (selectedDirAction == contextMenuData.removeDirAction) {
                     this->removeEntry(selectedItem);
-                } else if (selectedDirAction == contextMenuData.extractDirAction) {
-                    this->window->extractDir(path);
                 }
             } else {
-                // Show the directory context menu at the requested position
+                // Show the file context menu at the requested position
                 auto* selectedFileAction = contextMenuData.contextMenuFile->exec(this->mapToGlobal(pos));
 
                 // Handle the selected action
-                if (selectedFileAction == contextMenuData.removeFileAction) {
-                    this->removeEntry(selectedItem);
-                } else if (selectedFileAction == contextMenuData.extractFileAction) {
+                if (selectedFileAction == contextMenuData.extractFileAction) {
                     this->window->extractFile(path);
+                } else if (selectedFileAction == contextMenuData.removeFileAction) {
+                    this->removeEntry(selectedItem);
                 }
             }
         }

--- a/src/gui/EntryTree.cpp
+++ b/src/gui/EntryTree.cpp
@@ -124,6 +124,8 @@ void EntryTree::selectSubItem(const QString& name) {
                 child->setSelected(true);
                 this->onCurrentItemChanged(child);
                 child->setExpanded(true);
+                this->scrollToItem(child, QAbstractItemView::ScrollHint::PositionAtCenter);
+                return;
             }
         }
     }

--- a/src/gui/EntryTree.cpp
+++ b/src/gui/EntryTree.cpp
@@ -126,13 +126,19 @@ void EntryTree::selectSubItem(const QString& name) {
 }
 
 void EntryTree::setSearchQuery(const QString& query) {
+    // Set items that contain a word in the query visible
+    const auto words = query.split(' ');
     for (QTreeWidgetItemIterator it(this); *it; ++it) {
         QTreeWidgetItem* item = (*it);
         item->setHidden(false);
-        if (item->childCount() == 0 && !item->text(0).contains(query, Qt::CaseInsensitive)) {
-            item->setHidden(true);
+        for (const auto& word : words) {
+            if (item->childCount() == 0 && !item->text(0).contains(word, Qt::CaseInsensitive)) {
+                item->setHidden(true);
+            }
         }
     }
+
+    // Hide directories that have no children
     int dirsTouched;
     do {
         dirsTouched = 0;

--- a/src/gui/EntryTree.cpp
+++ b/src/gui/EntryTree.cpp
@@ -171,6 +171,27 @@ void EntryTree::setAutoExpandDirectoryOnClick(bool enable) {
     this->autoExpandDirectories = enable;
 }
 
+void EntryTree::removeEntryByPath(const QString& path) {
+    auto elements = path.split('/');
+    auto* currentEntry = this->root;
+
+    while (!elements.isEmpty()) {
+        auto* oldEntry = currentEntry;
+        for (int i = 0; i < currentEntry->childCount(); i++) {
+            if (currentEntry->child(i)->text(0) == elements[0]) {
+                elements.pop_front();
+                currentEntry = currentEntry->child(i);
+                break;
+            }
+        }
+        if (oldEntry == currentEntry) {
+            return;
+        }
+    }
+
+    this->removeEntry(currentEntry);
+}
+
 void EntryTree::clearContents() {
     this->root = nullptr;
     this->clear();
@@ -252,6 +273,7 @@ void EntryTree::removeEntry(QTreeWidgetItem* item) {
 
     // Remove dead directories
     while (parent && parent != this->root && parent->childCount() == 0) {
+        this->window->removeDir(this->getItemPath(parent));
         auto* temp = parent->parent();
         delete parent;
         parent = temp;

--- a/src/gui/EntryTree.h
+++ b/src/gui/EntryTree.h
@@ -27,6 +27,8 @@ public:
 
     void setAutoExpandDirectoryOnClick(bool enable);
 
+    void removeEntryByPath(const QString& path);
+
     void clearContents();
 
     void addEntry(const QString& path);

--- a/src/gui/EntryTree.h
+++ b/src/gui/EntryTree.h
@@ -32,7 +32,7 @@ public:
     void addEntry(const QString& path);
 
 public slots:
-    void onItemClicked(QTreeWidgetItem* item, int /*column*/);
+    void onCurrentItemChanged(QTreeWidgetItem* item /*, QTreeWidgetItem* previous*/);
 
 private:
     [[nodiscard]] QString getItemPath(QTreeWidgetItem* item);

--- a/src/gui/FileViewer.cpp
+++ b/src/gui/FileViewer.cpp
@@ -77,6 +77,10 @@ void FileViewer::displayDir(const QString& path, const QList<QString>& subfolder
     this->showPreview<DirPreview>();
 }
 
+void FileViewer::setSearchQuery(const QString& query) {
+    this->getPreview<DirPreview>()->setSearchQuery(query);
+}
+
 void FileViewer::selectSubItemInDir(const QString& name) {
     this->window->selectSubItemInDir(name);
 }

--- a/src/gui/FileViewer.cpp
+++ b/src/gui/FileViewer.cpp
@@ -39,7 +39,10 @@ FileViewer::FileViewer(Window* window_, QWidget* parent)
 }
 
 void FileViewer::displayEntry(const QString& path) {
-    QString extension(std::filesystem::path(path.toLower().toStdString()).extension().string().c_str());
+    // Get extension
+    std::filesystem::path helperPath(path.toLower().toStdString());
+    QString extension(helperPath.has_extension() ? helperPath.extension().string().c_str() : helperPath.stem().string().c_str());
+
     this->clearContents();
     if (ImagePreview::EXTENSIONS.contains(extension)) {
         // Image

--- a/src/gui/FileViewer.cpp
+++ b/src/gui/FileViewer.cpp
@@ -20,7 +20,7 @@ FileViewer::FileViewer(Window* window_, QWidget* parent)
     auto* layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
 
-    auto* dirPreview = newPreview<DirPreview>(this, this);
+    auto* dirPreview = newPreview<DirPreview>(this, this->window, this);
     layout->addWidget(dirPreview);
 
     auto* errorPreview = newPreview<ErrorPreview>(this);
@@ -71,9 +71,9 @@ void FileViewer::displayEntry(const QString& path) {
     }
 }
 
-void FileViewer::displayDir(const QString& /*path*/, const QList<QString>& subfolders, const QList<QString>& entryPaths, const VPK& vpk) {
+void FileViewer::displayDir(const QString& path, const QList<QString>& subfolders, const QList<QString>& entryPaths, const VPK& vpk) {
     this->clearContents();
-    this->getPreview<DirPreview>()->setPath(subfolders, entryPaths, vpk);
+    this->getPreview<DirPreview>()->setPath(path, subfolders, entryPaths, vpk);
     this->showPreview<DirPreview>();
 }
 

--- a/src/gui/FileViewer.cpp
+++ b/src/gui/FileViewer.cpp
@@ -80,6 +80,22 @@ void FileViewer::displayDir(const QString& path, const QList<QString>& subfolder
     this->showPreview<DirPreview>();
 }
 
+void FileViewer::addEntry(const vpkedit::VPK& vpk, const QString& path) {
+    this->getPreview<DirPreview>()->addEntry(vpk, path);
+}
+
+void FileViewer::removeFile(const QString& path) {
+    this->getPreview<DirPreview>()->removeFile(path);
+}
+
+void FileViewer::removeDir(const QString& path) {
+    if (path == this->getPreview<DirPreview>()->getCurrentPath()) {
+        this->hidePreview<DirPreview>();
+        return;
+    }
+    this->getPreview<DirPreview>()->removeDir(path);
+}
+
 void FileViewer::setSearchQuery(const QString& query) {
     this->getPreview<DirPreview>()->setSearchQuery(query);
 }

--- a/src/gui/FileViewer.h
+++ b/src/gui/FileViewer.h
@@ -25,6 +25,12 @@ public:
 
     void displayDir(const QString& path, const QList<QString>& subfolders, const QList<QString>& entryPaths, const vpkedit::VPK& vpk);
 
+    void addEntry(const vpkedit::VPK& vpk, const QString& path);
+
+    void removeFile(const QString& path);
+
+    void removeDir(const QString& path);
+
     void setSearchQuery(const QString& query);
 
     void selectSubItemInDir(const QString& name);
@@ -37,7 +43,7 @@ private:
     std::unordered_map<std::type_index, QWidget*> previews;
 
     template<typename T, typename... Args>
-    T* newPreview(Args... args) {
+    inline T* newPreview(Args... args) {
         auto* preview = new T(std::forward<Args>(args)...);
         this->previews[std::type_index(typeid(T))] = preview;
         return preview;
@@ -49,10 +55,15 @@ private:
     }
 
     template<typename T>
-    void showPreview() {
+    inline void showPreview() {
         for (const auto [index, widget] : this->previews) {
             widget->hide();
         }
         this->previews.at(std::type_index(typeid(T)))->show();
+    }
+
+    template<typename T>
+    inline void hidePreview() {
+        this->previews.at(std::type_index(typeid(T)))->hide();
     }
 };

--- a/src/gui/FileViewer.h
+++ b/src/gui/FileViewer.h
@@ -25,6 +25,8 @@ public:
 
     void displayDir(const QString& path, const QList<QString>& subfolders, const QList<QString>& entryPaths, const vpkedit::VPK& vpk);
 
+    void setSearchQuery(const QString& query);
+
     void selectSubItemInDir(const QString& name);
 
     void clearContents();

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -211,7 +211,7 @@ Window::Window(QSettings& options, QWidget* parent)
 
     this->searchBar = new QLineEdit(leftPane);
     this->searchBar->setPlaceholderText(QString("Find..."));
-    connect(this->searchBar, &QLineEdit::returnPressed, this, [=] {
+    QObject::connect(this->searchBar, &QLineEdit::editingFinished, this, [=] {
         this->entryTree->setSearchQuery(this->searchBar->text());
     });
     leftPaneLayout->addWidget(this->searchBar);

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -289,7 +289,9 @@ void Window::openVPK(const QString& startPath) {
     if (path.isEmpty()) {
         return;
     }
-    this->loadVPK(path);
+    if (!this->loadVPK(path)) {
+        this->clearContents();
+    }
 }
 
 bool Window::saveVPK() {

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -385,6 +385,7 @@ void Window::addFile(const QString& startPath) {
     this->vpk->addEntry(entryPath.toStdString(), filepath.toStdString(), !useArchiveVPK, preloadBytes);
     this->markModified(true);
     this->entryTree->addEntry(entryPath);
+    this->fileViewer->addEntry(this->vpk.value(), entryPath);
 }
 
 void Window::addDir(const QString& startPath) {
@@ -412,17 +413,27 @@ void Window::addDir(const QString& startPath) {
         QString subEntryPath = parentEntryPath + subEntryPathFS.sliced(dirPath.length());
         this->vpk->addEntry(subEntryPath.toStdString(), subEntryPathFS.toStdString(), !useArchiveVPK, preloadBytes);
         this->entryTree->addEntry(subEntryPath);
+        this->fileViewer->addEntry(this->vpk.value(), subEntryPath);
     }
     this->markModified(true);
 }
 
-bool Window::removeFile(const QString& filepath) {
-    if (!this->vpk->removeEntry(filepath.toStdString())) {
-        QMessageBox::critical(this, tr("Error Removing File"), tr("There was an error removing the file at \"%1\"").arg(filepath));
+bool Window::removeFile(const QString& path) {
+    if (!this->vpk->removeEntry(path.toStdString())) {
+        QMessageBox::critical(this, tr("Error Removing File"), tr("There was an error removing the file at \"%1\"").arg(path));
         return false;
     }
+    this->fileViewer->removeFile(path);
     this->markModified(true);
     return true;
+}
+
+void Window::removeDir(const QString& path) {
+    this->fileViewer->removeDir(path);
+}
+
+void Window::requestEntryRemoval(const QString& path) {
+    this->entryTree->removeEntryByPath(path);
 }
 
 void Window::about() {

--- a/src/gui/Window.cpp
+++ b/src/gui/Window.cpp
@@ -213,6 +213,7 @@ Window::Window(QSettings& options, QWidget* parent)
     this->searchBar->setPlaceholderText(QString("Find..."));
     QObject::connect(this->searchBar, &QLineEdit::editingFinished, this, [=] {
         this->entryTree->setSearchQuery(this->searchBar->text());
+        this->fileViewer->setSearchQuery(this->searchBar->text());
     });
     leftPaneLayout->addWidget(this->searchBar);
 

--- a/src/gui/Window.h
+++ b/src/gui/Window.h
@@ -43,7 +43,11 @@ public:
 
     void addDir(const QString& startDir = QString());
 
-    bool removeFile(const QString& filepath);
+    bool removeFile(const QString& path);
+
+    void removeDir(const QString& path);
+
+    void requestEntryRemoval(const QString& path);
 
     void about();
 

--- a/src/gui/Window.h
+++ b/src/gui/Window.h
@@ -41,6 +41,8 @@ public:
 
     void addFile(const QString& startDir = QString());
 
+    void addDir(const QString& startDir = QString());
+
     bool removeFile(const QString& filepath);
 
     void about();

--- a/src/gui/popups/NewEntryDialog.h
+++ b/src/gui/popups/NewEntryDialog.h
@@ -13,9 +13,9 @@ class NewEntryDialog : public QDialog {
     Q_OBJECT;
 
 public:
-    explicit NewEntryDialog(QWidget* parent = nullptr, const QString& prefilledPath = QString());
+    NewEntryDialog(bool isDir, const QString& prefilledPath = QString(), QWidget* parent = nullptr);
 
-    static std::optional<std::tuple<QString, bool, int>> getNewEntryOptions(QWidget* parent = nullptr, const QString& prefilledPath = QString());
+    static std::optional<std::tuple<QString, bool, int>> getNewEntryOptions(bool isDir, const QString& prefilledPath = QString(), QWidget* parent = nullptr);
 
 private:
     QLineEdit* path;

--- a/src/gui/previews/DirPreview.cpp
+++ b/src/gui/previews/DirPreview.cpp
@@ -52,24 +52,26 @@ DirPreview::DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent
                 auto* selectedDirAction = contextMenuData.contextMenuDir->exec(this->mapToGlobal(pos));
 
                 // Handle the selected action
-                if (selectedDirAction == contextMenuData.addFileToDirAction) {
-                    this->window->addFile(path);
-                } else if (selectedDirAction == contextMenuData.removeDirAction) {
-                    // todo: remove entry from dir preview
-                    //this->removeEntry(selectedItem);
-                } else if (selectedDirAction == contextMenuData.extractDirAction) {
+                if (selectedDirAction == contextMenuData.extractDirAction) {
                     this->window->extractDir(path);
+                } else if (selectedDirAction == contextMenuData.addFileToDirAction) {
+                    this->window->addFile(path);
+                } else if (selectedDirAction == contextMenuData.addDirToDirAction) {
+                    this->window->addDir(path);
+                } else if (selectedDirAction == contextMenuData.removeDirAction) {
+                    // todo(sync): remove entry from dir preview
+                    //this->removeEntry(selectedItem);
                 }
             } else {
-                // Show the directory context menu at the requested position
+                // Show the file context menu at the requested position
                 auto* selectedFileAction = contextMenuData.contextMenuFile->exec(this->mapToGlobal(pos));
 
                 // Handle the selected action
-                if (selectedFileAction == contextMenuData.removeFileAction) {
-                    // todo: remove entry from dir preview
-                    //this->removeEntry(selectedItem);
-                } else if (selectedFileAction == contextMenuData.extractFileAction) {
+                if (selectedFileAction == contextMenuData.extractFileAction) {
                     this->window->extractFile(path);
+                } else if (selectedFileAction == contextMenuData.removeFileAction) {
+                    // todo(sync): remove entry from dir preview
+                    //this->removeEntry(selectedItem);
                 }
             }
         }

--- a/src/gui/previews/DirPreview.cpp
+++ b/src/gui/previews/DirPreview.cpp
@@ -11,18 +11,32 @@
 
 using namespace vpkedit;
 
+constexpr int KB_SIZE = 1024;
+
 constexpr const char* DIR_TYPE_NAME = "Folder";
+
+namespace DirPreviewColumn {
+
+constexpr int NAME = 0;
+constexpr int TYPE = 1;
+constexpr int TOTAL_SIZE = 2;
+constexpr int PRELOADED_SIZE = 3;
+constexpr int ARCHIVE_INDEX = 4;
+
+constexpr int NUM_COLUMNS = 5;
+
+} // namespace DirPreviewColumn
 
 DirPreview::DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent)
         : QTableWidget(parent)
         , fileViewer(fileViewer_)
         , window(window_) {
-    this->setColumnCount(5);
-    this->setColumnWidth(0, 250);
-    this->setColumnWidth(1, 50);
-    this->setColumnWidth(2, 100);
-    this->setColumnWidth(3, 100);
-    this->setColumnWidth(4, 100);
+    this->setColumnCount(DirPreviewColumn::NUM_COLUMNS);
+    this->setColumnWidth(DirPreviewColumn::NAME, 250);
+    this->setColumnWidth(DirPreviewColumn::TYPE, 50);
+    this->setColumnWidth(DirPreviewColumn::TOTAL_SIZE, 100);
+    this->setColumnWidth(DirPreviewColumn::PRELOADED_SIZE, 100);
+    this->setColumnWidth(DirPreviewColumn::ARCHIVE_INDEX, 100);
     this->horizontalHeader()->setStretchLastSection(true);
     this->verticalHeader()->hide();
     this->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -33,7 +47,7 @@ DirPreview::DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent
     QObject::connect(this, &QTableWidget::customContextMenuRequested, [=](const QPoint& pos) {
         if (auto* selectedItem = this->itemAt(pos)) {
             QString path = this->getItemPath(selectedItem);
-            if (this->item(selectedItem->row(), 1)->text() == DIR_TYPE_NAME) {
+            if (this->item(selectedItem->row(), DirPreviewColumn::TYPE)->text() == DIR_TYPE_NAME) {
                 // Show the directory context menu at the requested position
                 auto* selectedDirAction = contextMenuData.contextMenuDir->exec(this->mapToGlobal(pos));
 
@@ -62,7 +76,7 @@ DirPreview::DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent
     });
 
     QObject::connect(this, &QTableWidget::doubleClicked, [=](const QModelIndex& index) {
-        this->fileViewer->selectSubItemInDir(this->item(index.row(), 0)->text());
+        this->fileViewer->selectSubItemInDir(this->item(index.row(), DirPreviewColumn::NAME)->text());
     });
 }
 
@@ -77,15 +91,15 @@ void DirPreview::setPath(const QString& currentDir, const QList<QString>& subfol
         this->setRowCount(this->rowCount() + 1);
 
         auto* nameItem = new QTableWidgetItem(subfolder);
-        this->setItem(this->rowCount() - 1, 0, nameItem);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::NAME, nameItem);
 
-        auto* typeItem = new QTableWidgetItem(QString(DIR_TYPE_NAME));
-        this->setItem(this->rowCount() - 1, 1, typeItem);
+        auto* typeItem = new QTableWidgetItem(DIR_TYPE_NAME);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::TYPE, typeItem);
 
         // Need to fill the rest of the columns with an item to fix the context menu not showing up on these cells
-        this->setItem(this->rowCount() - 1, 2, new QTableWidgetItem(""));
-        this->setItem(this->rowCount() - 1, 3, new QTableWidgetItem(""));
-        this->setItem(this->rowCount() - 1, 4, new QTableWidgetItem(""));
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::TOTAL_SIZE, new QTableWidgetItem(""));
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::PRELOADED_SIZE, new QTableWidgetItem(""));
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::ARCHIVE_INDEX, new QTableWidgetItem(""));
     }
 
     for (const auto& path : entryPaths) {
@@ -97,42 +111,75 @@ void DirPreview::setPath(const QString& currentDir, const QList<QString>& subfol
         this->setRowCount(this->rowCount() + 1);
 
         auto* nameItem = new QTableWidgetItem(entry->filename.c_str());
-        this->setItem(this->rowCount() - 1, 0, nameItem);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::NAME, nameItem);
 
         auto* typeItem = new QTableWidgetItem(QString(entry->filenamePair.second.c_str()).toUpper());
-        this->setItem(this->rowCount() - 1, 1, typeItem);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::TYPE, typeItem);
 
         QTableWidgetItem* sizeItem;
-        if (entry->length < 1024) {
+        if (entry->length < KB_SIZE) {
             sizeItem = new QTableWidgetItem(QString::number(entry->length) + " bytes");
         } else {
-            auto size = static_cast<double>(entry->length) / 1024.0;
+            auto size = static_cast<double>(entry->length) / KB_SIZE;
             QString extension(" kb");
 
-            if (size >= 1024) {
-                size /= 1024.0;
+            if (size >= KB_SIZE) {
+                size /= KB_SIZE;
                 extension = " mb";
             }
-            if (size >= 1024) {
-                size /= 1024.0;
+            if (size >= KB_SIZE) {
+                size /= KB_SIZE;
                 extension = " gb";
             }
             sizeItem = new QTableWidgetItem(QString::number(size, 'f', 2) + extension);
         }
-        this->setItem(this->rowCount() - 1, 2, sizeItem);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::TOTAL_SIZE, sizeItem);
 
         auto* preloadedSizeItem = new QTableWidgetItem(QString::number(entry->preloadedData.size()) + " bytes");
-        this->setItem(this->rowCount() - 1, 3, preloadedSizeItem);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::PRELOADED_SIZE, preloadedSizeItem);
 
         auto archiveIndex = entry->archiveIndex;
         // If the archive index is the dir index, it's included in the directory VPK
         auto* archiveIndexItem = new QTableWidgetItem(archiveIndex == VPK_DIR_INDEX ? QString("N/A") : QString::number(archiveIndex));
-        this->setItem(this->rowCount() - 1, 4, archiveIndexItem);
+        this->setItem(this->rowCount() - 1, DirPreviewColumn::ARCHIVE_INDEX, archiveIndexItem);
+    }
+
+    // Make sure the active search query is applied
+    this->setSearchQuery(this->currentSearchQuery);
+}
+
+void DirPreview::setSearchQuery(const QString& query) {
+    // Copy query to use when resetting the preview
+    this->currentSearchQuery = query;
+
+    // If the query is empty, show everything
+    if (query.isEmpty()) {
+        for (int r = 0; r < this->rowCount(); r++) {
+            this->showRow(r);
+        }
+        return;
+    }
+
+    // Set items that contain a word in the query visible
+    const auto words = query.split(' ');
+    for (int r = 0; r < this->rowCount(); r++) {
+        this->showRow(r);
+
+        // todo(search): use the entry tree visibility status to inform which directories should be shown
+        if (this->item(r, DirPreviewColumn::TYPE)->text() == DIR_TYPE_NAME) {
+            continue;
+        }
+
+        for (const auto& word: words) {
+            if (!this->item(r, DirPreviewColumn::NAME)->text().contains(word, Qt::CaseInsensitive)) {
+                this->hideRow(r);
+            }
+        }
     }
 }
 
 QString DirPreview::getItemPath(QTableWidgetItem* item) {
-    QString entryName = this->item(item->row(), 0)->text();
+    QString entryName = this->item(item->row(), DirPreviewColumn::NAME)->text();
     if (currentPath.isEmpty()) {
         return entryName;
     }

--- a/src/gui/previews/DirPreview.cpp
+++ b/src/gui/previews/DirPreview.cpp
@@ -1,16 +1,22 @@
 #include "DirPreview.h"
 
 #include <QHeaderView>
+#include <QMenu>
 
 #include <vpkedit/VPK.h>
 
+#include "../EntryContextMenuData.h"
 #include "../FileViewer.h"
+#include "../Window.h"
 
 using namespace vpkedit;
 
-DirPreview::DirPreview(FileViewer* fileViewer_, QWidget* parent)
+constexpr const char* DIR_TYPE_NAME = "Folder";
+
+DirPreview::DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent)
         : QTableWidget(parent)
-        , fileViewer(fileViewer_) {
+        , fileViewer(fileViewer_)
+        , window(window_) {
     this->setColumnCount(5);
     this->setColumnWidth(0, 250);
     this->setColumnWidth(1, 50);
@@ -22,15 +28,50 @@ DirPreview::DirPreview(FileViewer* fileViewer_, QWidget* parent)
     this->setSelectionBehavior(QAbstractItemView::SelectRows);
     this->setEditTriggers(QAbstractItemView::NoEditTriggers);
 
+    this->setContextMenuPolicy(Qt::CustomContextMenu);
+    EntryContextMenuData contextMenuData(false, this);
+    QObject::connect(this, &QTableWidget::customContextMenuRequested, [=](const QPoint& pos) {
+        if (auto* selectedItem = this->itemAt(pos)) {
+            QString path = this->getItemPath(selectedItem);
+            if (this->item(selectedItem->row(), 1)->text() == DIR_TYPE_NAME) {
+                // Show the directory context menu at the requested position
+                auto* selectedDirAction = contextMenuData.contextMenuDir->exec(this->mapToGlobal(pos));
+
+                // Handle the selected action
+                if (selectedDirAction == contextMenuData.addFileToDirAction) {
+                    this->window->addFile(path);
+                } else if (selectedDirAction == contextMenuData.removeDirAction) {
+                    // todo: remove entry from dir preview
+                    //this->removeEntry(selectedItem);
+                } else if (selectedDirAction == contextMenuData.extractDirAction) {
+                    this->window->extractDir(path);
+                }
+            } else {
+                // Show the directory context menu at the requested position
+                auto* selectedFileAction = contextMenuData.contextMenuFile->exec(this->mapToGlobal(pos));
+
+                // Handle the selected action
+                if (selectedFileAction == contextMenuData.removeFileAction) {
+                    // todo: remove entry from dir preview
+                    //this->removeEntry(selectedItem);
+                } else if (selectedFileAction == contextMenuData.extractFileAction) {
+                    this->window->extractFile(path);
+                }
+            }
+        }
+    });
+
     QObject::connect(this, &QTableWidget::doubleClicked, [=](const QModelIndex& index) {
         this->fileViewer->selectSubItemInDir(this->item(index.row(), 0)->text());
     });
 }
 
-void DirPreview::setPath(const QList<QString>& subfolders, const QList<QString>& entryPaths, const VPK& vpk) {
+void DirPreview::setPath(const QString& currentDir, const QList<QString>& subfolders, const QList<QString>& entryPaths, const VPK& vpk) {
     this->clear();
     this->setRowCount(0);
     this->setHorizontalHeaderLabels({"Name", "Type", "Size", "Preloaded Size", "Archive Index"});
+
+    this->currentPath = currentDir;
 
     for (const auto& subfolder : subfolders) {
         this->setRowCount(this->rowCount() + 1);
@@ -38,8 +79,13 @@ void DirPreview::setPath(const QList<QString>& subfolders, const QList<QString>&
         auto* nameItem = new QTableWidgetItem(subfolder);
         this->setItem(this->rowCount() - 1, 0, nameItem);
 
-        auto* typeItem = new QTableWidgetItem(QString("Folder"));
+        auto* typeItem = new QTableWidgetItem(QString(DIR_TYPE_NAME));
         this->setItem(this->rowCount() - 1, 1, typeItem);
+
+        // Need to fill the rest of the columns with an item to fix the context menu not showing up on these cells
+        this->setItem(this->rowCount() - 1, 2, new QTableWidgetItem(""));
+        this->setItem(this->rowCount() - 1, 3, new QTableWidgetItem(""));
+        this->setItem(this->rowCount() - 1, 4, new QTableWidgetItem(""));
     }
 
     for (const auto& path : entryPaths) {
@@ -83,4 +129,12 @@ void DirPreview::setPath(const QList<QString>& subfolders, const QList<QString>&
         auto* archiveIndexItem = new QTableWidgetItem(archiveIndex == VPK_DIR_INDEX ? QString("N/A") : QString::number(archiveIndex));
         this->setItem(this->rowCount() - 1, 4, archiveIndexItem);
     }
+}
+
+QString DirPreview::getItemPath(QTableWidgetItem* item) {
+    QString entryName = this->item(item->row(), 0)->text();
+    if (currentPath.isEmpty()) {
+        return entryName;
+    }
+    return this->currentPath + '/' + entryName;
 }

--- a/src/gui/previews/DirPreview.h
+++ b/src/gui/previews/DirPreview.h
@@ -15,13 +15,25 @@ class DirPreview : public QTableWidget {
     Q_OBJECT;
 
 public:
-    explicit DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent = nullptr);
+    DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent = nullptr);
 
     void setPath(const QString& currentDir, const QList<QString>& subfolders, const QList<QString>& entryPaths, const vpkedit::VPK& vpk);
 
+    void addEntry(const vpkedit::VPK& vpk, const QString& path);
+
+    void removeFile(const QString& path);
+
+    void removeDir(const QString& path);
+
     void setSearchQuery(const QString& query);
 
+    [[nodiscard]] const QString& getCurrentPath() const;
+
 private:
+    void addRowForFile(const vpkedit::VPK& vpk, const QString& path);
+
+    void addRowForDir(const QString& name);
+
     QString getItemPath(QTableWidgetItem* item);
 
     FileViewer* fileViewer;

--- a/src/gui/previews/DirPreview.h
+++ b/src/gui/previews/DirPreview.h
@@ -9,15 +9,21 @@ class VPK;
 } // namespace vpkedit
 
 class FileViewer;
+class Window;
 
 class DirPreview : public QTableWidget {
     Q_OBJECT;
 
 public:
-    explicit DirPreview(FileViewer* fileViewer_, QWidget* parent = nullptr);
+    explicit DirPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent = nullptr);
 
-    void setPath(const QList<QString>& subfolders, const QList<QString>& entryPaths, const vpkedit::VPK& vpk);
+    void setPath(const QString& currentDir, const QList<QString>& subfolders, const QList<QString>& entryPaths, const vpkedit::VPK& vpk);
 
 private:
+    QString getItemPath(QTableWidgetItem* item);
+
     FileViewer* fileViewer;
+    Window* window;
+
+    QString currentPath;
 };

--- a/src/gui/previews/DirPreview.h
+++ b/src/gui/previews/DirPreview.h
@@ -19,6 +19,8 @@ public:
 
     void setPath(const QString& currentDir, const QList<QString>& subfolders, const QList<QString>& entryPaths, const vpkedit::VPK& vpk);
 
+    void setSearchQuery(const QString& query);
+
 private:
     QString getItemPath(QTableWidgetItem* item);
 
@@ -26,4 +28,5 @@ private:
     Window* window;
 
     QString currentPath;
+    QString currentSearchQuery;
 };

--- a/src/gui/previews/ImagePreview.cpp
+++ b/src/gui/previews/ImagePreview.cpp
@@ -3,6 +3,7 @@
 #include <QHBoxLayout>
 #include <QPainter>
 #include <QSlider>
+#include <QWheelEvent>
 
 Image::Image(QWidget* parent)
         : QWidget(parent)
@@ -17,7 +18,7 @@ void Image::setZoom(int zoom_) {
     this->zoom = static_cast<float>(zoom_) / 100.f;
 }
 
-void Image::paintEvent(QPaintEvent* event) {
+void Image::paintEvent(QPaintEvent* /*event*/) {
     QPainter painter(this);
 
     int imageWidth = this->image.width(), imageHeight = this->image.height();
@@ -46,7 +47,7 @@ ImagePreview::ImagePreview(QWidget* parent)
     this->zoomSlider->setMinimum(20);
     this->zoomSlider->setMaximum(800);
     this->zoomSlider->setValue(100);
-    connect(this->zoomSlider, &QSlider::valueChanged, [&] {
+    QObject::connect(this->zoomSlider, &QSlider::valueChanged, [&] {
         this->image->setZoom(this->zoomSlider->value());
         this->image->repaint();
     });
@@ -56,4 +57,11 @@ ImagePreview::ImagePreview(QWidget* parent)
 void ImagePreview::setImage(const std::vector<std::byte>& data) {
     this->image->setImage(data);
     this->zoomSlider->setValue(100);
+}
+
+void ImagePreview::wheelEvent(QWheelEvent* event) {
+    if (QPoint numDegrees = event->angleDelta() / 8; !numDegrees.isNull()) {
+        this->zoomSlider->setValue(this->zoomSlider->value() + numDegrees.y());
+    }
+    event->accept();
 }

--- a/src/gui/previews/ImagePreview.h
+++ b/src/gui/previews/ImagePreview.h
@@ -43,6 +43,9 @@ public:
 
     void setImage(const std::vector<std::byte>& data);
 
+protected:
+    void wheelEvent(QWheelEvent* event) override;
+
 private:
     Image* image;
     QSlider* zoomSlider;

--- a/src/gui/previews/TextPreview.cpp
+++ b/src/gui/previews/TextPreview.cpp
@@ -2,6 +2,7 @@
 
 TextPreview::TextPreview(QWidget* parent)
         : QTextEdit(parent) {
+    // todo(preview): allow editing text files
     this->setReadOnly(true);
 
     QFont monospace;

--- a/src/gui/previews/TextPreview.h
+++ b/src/gui/previews/TextPreview.h
@@ -12,6 +12,8 @@ public:
         ".gi",
         ".rc",
         ".res",
+        ".vmt",
+        ".vmf",
         ".vbsp",
         ".rad",
         ".nut",
@@ -29,8 +31,17 @@ public:
         ".yml",
         ".yaml",
         ".toml",
-        ".vmf", // hey you never know
-        ".vmt",
+        ".html",
+        ".htm",
+        ".xml",
+        ".css",
+        ".scss",
+        ".sass",
+        ".gitignore",
+        "authors",
+        "credits",
+        "license",
+        "readme",
     };
 
     explicit TextPreview(QWidget* parent = nullptr);

--- a/src/gui/previews/VTFPreview.cpp
+++ b/src/gui/previews/VTFPreview.cpp
@@ -6,6 +6,7 @@
 #include <QPainter>
 #include <QSlider>
 #include <QSpinBox>
+#include <QWheelEvent>
 
 using namespace VTFLib;
 
@@ -78,7 +79,7 @@ float VTFImage::getZoom() const {
 }
 
 // Taken directly from vtex2, thanks!
-void VTFImage::paintEvent(QPaintEvent* event) {
+void VTFImage::paintEvent(QPaintEvent* /*event*/) {
     QPainter painter(this);
 
     if (!this->vtf) {
@@ -251,4 +252,11 @@ void VTFPreview::setImage(const std::vector<std::byte>& data) {
     this->tileCheckBox->setChecked(false);
 
     this->zoomSlider->setValue(100);
+}
+
+void VTFPreview::wheelEvent(QWheelEvent* event) {
+    if (QPoint numDegrees = event->angleDelta() / 8; !numDegrees.isNull()) {
+        this->zoomSlider->setValue(this->zoomSlider->value() + numDegrees.y());
+    }
+    event->accept();
 }

--- a/src/gui/previews/VTFPreview.h
+++ b/src/gui/previews/VTFPreview.h
@@ -65,6 +65,9 @@ public:
 
     void setImage(const std::vector<std::byte>& data);
 
+protected:
+    void wheelEvent(QWheelEvent* event) override;
+
 private:
     VTFImage* image;
     QSpinBox* frameSpin;


### PR DESCRIPTION
- Search
  - Split search queries into words instead of checking for the entire phrase
  - Search queries are now also applied when the text box loses focus instead of only when Enter/Return is pressed
  - Apply search queries to directory preview
    - Currently folders are always visible in directory preview since the preview itself has no idea what their contents are
- Keybinds
  - Scroll wheel zooms in/out of images and VTF files (closes #20)
  - Support using arrow keys to navigate the entry tree (closes #16)
- Main Window
  - Fix "New" actions being hidden after failing to load a vpk
  - Add entry context menu to directory preview (closes #15)
  - Add several more text formats to the text preview supported formats list
  - Add an "Add Folder" action in the context menu shown right-clicking a folder (closes #13)
  - Sync the entry tree and directory preview so they always match after modifying the VPK
  - Scroll to selected entry in entry tree when navigating in directory preview
- Bump minor version (version is now 3.4.0)