### PR TITLE
Preview `.gnut` files

### DIFF
--- a/src/gui/extensions/SingleFile.h
+++ b/src/gui/extensions/SingleFile.h
@@ -64,6 +64,7 @@ private:
 	VPKPP_REGISTER_PACKFILE_OPEN(".txt", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".md", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".nut", &SingleFile::open);
+	VPKPP_REGISTER_PACKFILE_OPEN(".gnut", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".lua", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".gm", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".py", &SingleFile::open);

--- a/src/gui/previews/TextPreview.h
+++ b/src/gui/previews/TextPreview.h
@@ -78,7 +78,7 @@ public:
 	// Reminder if you add a format that should be highlighted to change that list too!
 	static inline const QStringList EXTENSIONS {
 		".txt", ".md", // Text
-		".nut", ".lua", ".gm", ".py", ".js", ".ts", // Scripting
+		".nut", ".gnut", ".lua", ".gm", ".py", ".js", ".ts", // Scripting
 		".map", ".vmf", ".vmm", ".vmx", ".vmt", // Maps
 		".vcd", ".fgd", ".qc", ".qci", ".qcx", ".smd", // Models / FGD
 		".kv", ".kv3", ".res", ".vdf", ".acf", ".bns", // KeyValues


### PR DESCRIPTION
Titanfall 2 ( and technically Apex Legends ) ocasionally use `.gnut` files to store some of their scripts. This pr just adds the ability to preview them, even if VPKEdit can't open Titanfall VPKs yet.

![image](https://github.com/user-attachments/assets/a9ecba1e-7549-44a1-a914-78912f6e360a)
