### PR TITLE
Add `.set` files to text preview

### DIFF
--- a/src/gui/extensions/SingleFile.h
+++ b/src/gui/extensions/SingleFile.h
@@ -122,6 +122,7 @@ private:
 	VPKPP_REGISTER_PACKFILE_OPEN(".remap", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".pop", &SingleFile::open);
 	VPKPP_REGISTER_PACKFILE_OPEN(".edt", &SingleFile::open);
+	VPKPP_REGISTER_PACKFILE_OPEN(".set", &SingleFile::open);
 
 	// Textures
 	VPKPP_REGISTER_PACKFILE_OPEN(".tga", &SingleFile::open);

--- a/src/gui/previews/TextPreview.h
+++ b/src/gui/previews/TextPreview.h
@@ -89,8 +89,9 @@ public:
 		".gitignore", ".gitattributes", ".gitmodules", // Git
 		".gd", ".gdshader", ".tscn", ".tres", ".import", ".remap", // Godot
 		".zpc", ".zpdata", // Zombie Panic Survival
-		".pop", // TF2
+		".pop", // Team Fortress 2
 		".edt", // Synergy
+		".set", // Titanfall & Apex Legends
 	};
 
 	TextPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent = nullptr);


### PR DESCRIPTION
Another Titanfall branch file type. This one is used to store player classes and their settings. Also renamed `.pop` file's comment to prevent confusion

![image](https://github.com/user-attachments/assets/68990bf0-da91-46b2-bd41-87fafd961f35)
![image](https://github.com/user-attachments/assets/a617ce32-d905-480b-8e6c-fbcf55b0274c)
