### PR TITLE
gui: Using UTF-8 code pages in Windows

### DIFF
--- a/src/gui/_gui.cmake
+++ b/src/gui/_gui.cmake
@@ -183,6 +183,8 @@ if(WIN32)
     foreach(${PROJECT_NAME}_QTBASE_TRANSLATION IN LISTS ${PROJECT_NAME}_QTBASE_TRANSLATIONS)
         file(COPY "${${PROJECT_NAME}_QTBASE_TRANSLATION}" DESTINATION "${CMAKE_BINARY_DIR}/i18n")
     endforeach()
+
+    target_sources(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/windows.manifest")
 elseif(UNIX AND DEFINED QT_BASEDIR)
     configure_file("${QT_BASEDIR}/lib/libQt6Core.so.6"          "${CMAKE_BINARY_DIR}/libQt6Core.so.6"          COPYONLY)
     configure_file("${QT_BASEDIR}/lib/libQt6Gui.so.6"           "${CMAKE_BINARY_DIR}/libQt6Gui.so.6"           COPYONLY)

--- a/src/gui/windows.manifest
+++ b/src/gui/windows.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="nekomdl" version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page

Different languages of Windows may use different character encodings. 
Decoding with UTF-8 will destroy the original byte data (UTF-8 encoding replaces unrecognizable bytes with a certain character), resulting in an error when saving the file.

![a3123a32e5045b5f1c1fca330cb71da7](https://github.com/user-attachments/assets/1e543ae9-2aea-405c-ab6e-e36840813a0e)
![8b3e2f3a53a09d8440a1185120e280db](https://github.com/user-attachments/assets/3b9d2b8d-ff1d-4941-a741-a46abeb8d8fa)
![e71aae36e7b2761c39f82928496bed99](https://github.com/user-attachments/assets/ed227f2c-7de7-430c-98e7-1bfc64103a10)
