### PR TITLE
Unix-LF shit + .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Sources
+*.c   text diff=cpp
+*.cpp text diff=cpp
+*.h   text diff=cpp
+*.hpp text diff=cpp
+
+# Markdown
+*.md text eol=lf
+*.md linguist-detectable


### PR DESCRIPTION
Some .md's didn't exclusively use line-feeds without Carriage Returns, dealing with them. Also, I think azzyr would find this wise.