### PR TITLE
Swedish is "Arkiv," not "fil"

### DIFF
--- a/src/gui/res/i18n/vpkedit_sv.ts
+++ b/src/gui/res/i18n/vpkedit_sv.ts
@@ -419,7 +419,7 @@ Se nedan för mer information.</translation>
     <message>
       <location filename="../../Window.cpp" line="75"/>
       <source>File</source>
-      <translation>Fil</translation>
+      <translation>Arkiv</translation>
     </message>
     <message>
       <location filename="../../Window.cpp" line="123"/>


### PR DESCRIPTION
Those different applications I used in Swedish during these years (Notepad++ too) didn't call the first thing "Fil", but rather "Arkiv".

dUm i HuVeDet