### PR TITLE
feat(installer): initial flatpak packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # IDEs
+.devcontainer/
 .idea/
 .vs/
 .vscode/
@@ -7,7 +8,11 @@ CMakeSettings.json
 # Project exclude paths
 build/
 cmake-build-*/
+flatpak-build/
 out/
+
+# Flatpak builder
+**/.flatpak-builder/
 
 # Generated
 **/generated/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,12 +142,14 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/_gui.cmake")
 
 # Flatpak
 if(VPKEDIT_BUILD_FLATPAK)
-    include("${CMAKE_CURRENT_SOURCE_DIR}/src/installer/_flatpak.cmake")
+    include("${CMAKE_CURRENT_SOURCE_DIR}/src/installer/flatpak/_flatpak.cmake")
 endif()
 
 # Installer
-if(VPKEDIT_BUILD_INSTALLER)
+if(VPKEDIT_BUILD_INSTALLER AND NOT VPKEDIT_BUILD_FLATPAK)
     include("${CMAKE_CURRENT_SOURCE_DIR}/src/installer/_installer.cmake")
+elseif(VPKEDIT_BUILD_FLATPAK)
+    message(WARNING "You cannot build the ${PROJECT_NAME_PRETTY} installer and flatpak at the same time! The flatpak takes priority.")
 endif()
 
 # VS setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(VPKEDIT_USE_LTO "Build VPKEdit with link-time optimization enabled" OFF)
 
 option(VPKEDIT_BUILD_INSTALLER "Build VPKEdit installer" ON)
 if(UNIX)
-    option(VPKEDIT_BUILD_FLATPAK "Build VPKEdit flatpak (use in tandem with installer option)" OFF)
+    option(VPKEDIT_BUILD_FLATPAK "Build VPKEdit flatpak" OFF)
     set(VPKEDIT_FLATPAK_ID "info.${PROJECT_ORGANIZATION_NAME}.${PROJECT_NAME}" CACHE STRING "The ID of the Flatpak package")
 else()
     set(VPKEDIT_BUILD_FLATPAK OFF CACHE INTERNAL "" FORCE)
@@ -139,6 +139,11 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/src/cli/_cli.cmake")
 
 # vpkedit
 include("${CMAKE_CURRENT_SOURCE_DIR}/src/gui/_gui.cmake")
+
+# Flatpak
+if(VPKEDIT_BUILD_FLATPAK)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/src/installer/_flatpak.cmake")
+endif()
 
 # Installer
 if(VPKEDIT_BUILD_INSTALLER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,18 @@ set(PROJECT_ORGANIZATION_NAME "craftablescience" CACHE STRING "" FORCE)
 set(PROJECT_HOMEPAGE_URL_API "https://api.github.com/repos/craftablescience/VPKEdit" CACHE STRING "" FORCE)
 
 # Options
-option(VPKEDIT_BUILD_INSTALLER "Build installer for VPKEdit GUI application" ON)
 option(VPKEDIT_BUILD_FOR_STRATA_SOURCE "Build VPKEdit with the intent of the CLI/GUI going into the bin folder of a Strata Source game" OFF)
+
 option(VPKEDIT_USE_LTO "Build VPKEdit with link-time optimization enabled" OFF)
+
+option(VPKEDIT_BUILD_INSTALLER "Build VPKEdit installer" ON)
+if(UNIX)
+    option(VPKEDIT_BUILD_FLATPAK "Build VPKEdit flatpak (use in tandem with installer option)" OFF)
+    set(VPKEDIT_FLATPAK_ID "info.${PROJECT_ORGANIZATION_NAME}.${PROJECT_NAME}" CACHE STRING "The ID of the Flatpak package")
+else()
+    set(VPKEDIT_BUILD_FLATPAK OFF CACHE INTERNAL "" FORCE)
+    set(VPKEDIT_FLATPAK_ID "" CACHE INTERNAL "" FORCE)
+endif()
 
 # Global CMake options
 if(PROJECT_IS_TOP_LEVEL)

--- a/src/installer/_flatpak.cmake
+++ b/src/installer/_flatpak.cmake
@@ -1,0 +1,24 @@
+install(TARGETS ${PROJECT_NAME}cli ${PROJECT_NAME}
+        DESTINATION "bin/")
+
+# Desktop file
+configure_file(
+        "${CMAKE_CURRENT_LIST_DIR}/flatpak/desktop.in"
+        "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/${VPKEDIT_FLATPAK_ID}.desktop")
+install(FILES "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/${VPKEDIT_FLATPAK_ID}.desktop"
+        DESTINATION "share/applications/")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
+        DESTINATION "share/pixmaps/"
+        RENAME "${PROJECT_NAME}.png")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
+        DESTINATION "share/icons/hicolor/128x128/apps/"
+        RENAME "${VPKEDIT_FLATPAK_ID}.png")
+
+# MIME type info
+set(VPKEDIT_MIME_TYPE_ICON_ID "${VPKEDIT_FLATPAK_ID}" CACHE INTERNAL "" FORCE)
+configure_file(
+        "${CMAKE_CURRENT_LIST_DIR}/linux/mime-type.xml.in"
+        "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/mime-type.xml")
+install(FILES "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/mime-type.xml"
+        DESTINATION "share/mime/packages/"
+        RENAME "${VPKEDIT_FLATPAK_ID}.xml")

--- a/src/installer/_installer.cmake
+++ b/src/installer/_installer.cmake
@@ -1,20 +1,25 @@
 # Set up install rules
-install(TARGETS ${PROJECT_NAME}cli
-        DESTINATION .)
+if(VPKEDIT_BUILD_FLATPAK)
+    install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}cli
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+else()
+    install(TARGETS ${PROJECT_NAME}cli
+            DESTINATION .)
 
-install(TARGETS ${PROJECT_NAME}
-        DESTINATION .)
+    install(TARGETS ${PROJECT_NAME}
+            DESTINATION .)
 
-install(FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/CREDITS.md"
-        "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
-        "${CMAKE_CURRENT_LIST_DIR}/.nonportable"
-        DESTINATION .)
+    install(FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/CREDITS.md"
+            "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
+            "${CMAKE_CURRENT_LIST_DIR}/.nonportable"
+            DESTINATION .)
 
-foreach(${PROJECT_NAME}_QTBASE_TRANSLATION IN LISTS ${PROJECT_NAME}_QTBASE_TRANSLATIONS)
-    install(FILES "${${PROJECT_NAME}_QTBASE_TRANSLATION}"
-            DESTINATION i18n)
-endforeach()
+    foreach(${PROJECT_NAME}_QTBASE_TRANSLATION IN LISTS ${PROJECT_NAME}_QTBASE_TRANSLATIONS)
+        install(FILES "${${PROJECT_NAME}_QTBASE_TRANSLATION}"
+                DESTINATION i18n)
+    endforeach()
+endif()
 
 if(WIN32)
     install(IMPORTED_RUNTIME_ARTIFACTS
@@ -87,21 +92,22 @@ elseif(UNIX)
                 "${CMAKE_BINARY_DIR}/wayland-shell-integration"
                 "${CMAKE_BINARY_DIR}/xcbglintegrations"
                 DESTINATION .)
-    else()
+    elseif(NOT VPKEDIT_BUILD_FLATPAK)
         install(IMPORTED_RUNTIME_ARTIFACTS
                 Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg
                 RUNTIME DESTINATION .
                 LIBRARY DESTINATION .)
     endif()
 
+    set(desktop_file "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${FLATPAK_ID}.desktop")
     # Desktop file
     configure_file(
             "${CMAKE_CURRENT_LIST_DIR}/linux/desktop.in"
-            "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}.desktop")
-    install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}.desktop"
-            DESTINATION "/usr/share/applications/")
+            "${desktop_file}")
+    install(FILES "${desktop_file}"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications/")
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
-            DESTINATION "/usr/share/pixmaps/"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pixmaps/"
             RENAME "${PROJECT_NAME}.png")
 
     # MIME type info
@@ -109,11 +115,12 @@ elseif(UNIX)
             "${CMAKE_CURRENT_LIST_DIR}/linux/mime-type.xml.in"
             "${CMAKE_CURRENT_LIST_DIR}/linux/generated/mime-type.xml")
     install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/mime-type.xml"
-            DESTINATION "/usr/share/mime/packages/"
-            RENAME "${PROJECT_NAME}.xml")
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/mime/packages/"
+            RENAME "${FLATPAK_ID}.xml")
+
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
-            DESTINATION "/usr/share/icons/hicolor/128x128/mimetypes/"
-            RENAME "application-x-vpkedit.png")
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/128x128/apps/"
+            RENAME "${FLATPAK_ID}.png")
 endif()
 
 # CPack stuff
@@ -144,7 +151,7 @@ if(WIN32)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/win/generated/InstallCommands.nsh"   CPACK_NSIS_EXTRA_INSTALL_COMMANDS)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/win/generated/UninstallCommands.nsh" CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/win") # NSIS.template.in, NSIS.InstallOptions.ini.in
-else()
+elseif(NOT VPKEDIT_BUILD_FLATPAK)
     if(NOT (CPACK_GENERATOR STREQUAL "DEB"))
         message(WARNING "CPack generator must be DEB! Setting generator to DEB...")
         set(CPACK_GENERATOR "DEB" CACHE INTERNAL "" FORCE)
@@ -164,4 +171,6 @@ else()
     install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}"
             DESTINATION "/usr/bin")
 endif()
-include(CPack)
+if(NOT VPKEDIT_BUILD_FLATPAK)
+    include(CPack)
+endif()

--- a/src/installer/_installer.cmake
+++ b/src/installer/_installer.cmake
@@ -91,6 +91,8 @@ elseif(UNIX)
                 LIBRARY DESTINATION .)
     endif()
 
+    set(VPKEDIT_MIME_TYPE_ICON_ID "${PROJECT_NAME}" CACHE INTERNAL "" FORCE)
+
     # Desktop file
     configure_file(
             "${CMAKE_CURRENT_LIST_DIR}/linux/desktop.in"
@@ -102,7 +104,6 @@ elseif(UNIX)
             RENAME "${PROJECT_NAME}.png")
 
     # MIME type info
-    set(VPKEDIT_MIME_TYPE_ICON_ID "${PROJECT_NAME}" CACHE INTERNAL "" FORCE)
     configure_file(
             "${CMAKE_CURRENT_LIST_DIR}/linux/mime-type.xml.in"
             "${CMAKE_CURRENT_LIST_DIR}/linux/generated/mime-type.xml")

--- a/src/installer/_installer.cmake
+++ b/src/installer/_installer.cmake
@@ -1,25 +1,17 @@
 # Set up install rules
-if(VPKEDIT_BUILD_FLATPAK)
-    install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}cli
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
-else()
-    install(TARGETS ${PROJECT_NAME}cli
-            DESTINATION .)
+install(TARGETS ${PROJECT_NAME}cli ${PROJECT_NAME}
+        DESTINATION .)
 
-    install(TARGETS ${PROJECT_NAME}
-            DESTINATION .)
+install(FILES
+        "${CMAKE_CURRENT_SOURCE_DIR}/CREDITS.md"
+        "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
+        "${CMAKE_CURRENT_LIST_DIR}/.nonportable"
+        DESTINATION .)
 
-    install(FILES
-            "${CMAKE_CURRENT_SOURCE_DIR}/CREDITS.md"
-            "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
-            "${CMAKE_CURRENT_LIST_DIR}/.nonportable"
-            DESTINATION .)
-
-    foreach(${PROJECT_NAME}_QTBASE_TRANSLATION IN LISTS ${PROJECT_NAME}_QTBASE_TRANSLATIONS)
-        install(FILES "${${PROJECT_NAME}_QTBASE_TRANSLATION}"
-                DESTINATION i18n)
-    endforeach()
-endif()
+foreach(${PROJECT_NAME}_QTBASE_TRANSLATION IN LISTS ${PROJECT_NAME}_QTBASE_TRANSLATIONS)
+    install(FILES "${${PROJECT_NAME}_QTBASE_TRANSLATION}"
+            DESTINATION i18n)
+endforeach()
 
 if(WIN32)
     install(IMPORTED_RUNTIME_ARTIFACTS
@@ -92,35 +84,34 @@ elseif(UNIX)
                 "${CMAKE_BINARY_DIR}/wayland-shell-integration"
                 "${CMAKE_BINARY_DIR}/xcbglintegrations"
                 DESTINATION .)
-    elseif(NOT VPKEDIT_BUILD_FLATPAK)
+    else()
         install(IMPORTED_RUNTIME_ARTIFACTS
                 Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg
                 RUNTIME DESTINATION .
                 LIBRARY DESTINATION .)
     endif()
 
-    set(desktop_file "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${FLATPAK_ID}.desktop")
     # Desktop file
     configure_file(
             "${CMAKE_CURRENT_LIST_DIR}/linux/desktop.in"
-            "${desktop_file}")
-    install(FILES "${desktop_file}"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications/")
+            "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}.desktop")
+    install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}.desktop"
+            DESTINATION "/usr/share/applications/")
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pixmaps/"
+            DESTINATION "/usr/share/pixmaps/"
             RENAME "${PROJECT_NAME}.png")
 
     # MIME type info
+    set(VPKEDIT_MIME_TYPE_ICON_ID "${PROJECT_NAME}" CACHE INTERNAL "" FORCE)
     configure_file(
             "${CMAKE_CURRENT_LIST_DIR}/linux/mime-type.xml.in"
             "${CMAKE_CURRENT_LIST_DIR}/linux/generated/mime-type.xml")
     install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/mime-type.xml"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/mime/packages/"
-            RENAME "${FLATPAK_ID}.xml")
-
+            DESTINATION "/usr/share/mime/packages/"
+            RENAME "${PROJECT_NAME}.xml")
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/128x128/apps/"
-            RENAME "${FLATPAK_ID}.png")
+            DESTINATION "/usr/share/icons/hicolor/128x128/mimetypes/"
+            RENAME "application-x-vpkedit.png")
 endif()
 
 # CPack stuff
@@ -151,7 +142,7 @@ if(WIN32)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/win/generated/InstallCommands.nsh"   CPACK_NSIS_EXTRA_INSTALL_COMMANDS)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/win/generated/UninstallCommands.nsh" CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/win") # NSIS.template.in, NSIS.InstallOptions.ini.in
-elseif(NOT VPKEDIT_BUILD_FLATPAK)
+elseif(UNIX)
     if(NOT (CPACK_GENERATOR STREQUAL "DEB"))
         message(WARNING "CPack generator must be DEB! Setting generator to DEB...")
         set(CPACK_GENERATOR "DEB" CACHE INTERNAL "" FORCE)
@@ -171,6 +162,4 @@ elseif(NOT VPKEDIT_BUILD_FLATPAK)
     install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}"
             DESTINATION "/usr/bin")
 endif()
-if(NOT VPKEDIT_BUILD_FLATPAK)
-    include(CPack)
-endif()
+include(CPack)

--- a/src/installer/flatpak/Makefile
+++ b/src/installer/flatpak/Makefile
@@ -1,0 +1,31 @@
+.POSIX:
+# Development flatpak tasks
+
+FLATPAK_ID := info.craftablescience.vpkedit.Devel
+
+_GIT_TOPLEVEL := $(shell git rev-parse --show-toplevel)
+
+FLATPAK_BUILD_MANIFEST := $(realpath ./$(FLATPAK_ID).yaml)
+FLATPAK_BUILD_DIR := $(_GIT_TOPLEVEL)/flatpak-build/
+FLATPAK_REPO := $(_GIT_TOPLEVEL)/.flatpak-builder/cache
+
+FLATPAK_INSTALLATION := --system # or --user
+FLATPAK_BUILDER_FLAGS := --force-clean --install-deps-from=flathub --ccache --repo=$(FLATPAK_REPO) $(FLATPAK_INSTALLATION) $(FLATPAK_BUILDER_EXTRA_FLAGS)
+FLATPAK_INSTALL_FLAGS := --reinstall $(FLATPAK_INSTALLATION)
+
+flatpak:
+	cd $(_GIT_TOPLEVEL) && \
+	flatpak-builder $(FLATPAK_BUILDER_FLAGS) $(FLATPAK_BUILD_DIR) $(FLATPAK_BUILD_MANIFEST) || \
+	printf "you may need to add flathub to your target installation\n\
+	flatpak remote-add --if-not-exists %s flathub https://dl.flathub.org/repo/flathub.flatpakrepo\n" \
+	$(FLATPAK_INSTALLATION) \
+	2>&1
+
+# https://github.com/flatpak/flatpak/issues/5076
+# on debian stable flatpak inside container, cannot install without setting
+# session env due to lack of d-bus system bus to connect to parental controls api (?!!!)
+# set FLATPAK_SYSTEM_HELPER_ON_SESSION=1
+flatpak-install:
+	flatpak install $(FLATPAK_INSTALL_FLAGS) $(FLATPAK_REPO) $(FLATPAK_ID) $(FLATPAK_ID).Debug
+
+.PHONY: flatpak flatpak-install

--- a/src/installer/flatpak/_flatpak.cmake
+++ b/src/installer/flatpak/_flatpak.cmake
@@ -1,6 +1,8 @@
 install(TARGETS ${PROJECT_NAME}cli ${PROJECT_NAME}
         DESTINATION "bin/")
 
+set(VPKEDIT_MIME_TYPE_ICON_ID "${VPKEDIT_FLATPAK_ID}" CACHE INTERNAL "" FORCE)
+
 # Desktop file
 configure_file(
         "${CMAKE_CURRENT_LIST_DIR}/desktop.in"
@@ -15,7 +17,6 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
         RENAME "${VPKEDIT_FLATPAK_ID}.png")
 
 # MIME type info
-set(VPKEDIT_MIME_TYPE_ICON_ID "${VPKEDIT_FLATPAK_ID}" CACHE INTERNAL "" FORCE)
 configure_file(
         "${CMAKE_CURRENT_LIST_DIR}/../linux/mime-type.xml.in"
         "${CMAKE_CURRENT_LIST_DIR}/generated/mime-type.xml")

--- a/src/installer/flatpak/_flatpak.cmake
+++ b/src/installer/flatpak/_flatpak.cmake
@@ -3,9 +3,9 @@ install(TARGETS ${PROJECT_NAME}cli ${PROJECT_NAME}
 
 # Desktop file
 configure_file(
-        "${CMAKE_CURRENT_LIST_DIR}/flatpak/desktop.in"
-        "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/${VPKEDIT_FLATPAK_ID}.desktop")
-install(FILES "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/${VPKEDIT_FLATPAK_ID}.desktop"
+        "${CMAKE_CURRENT_LIST_DIR}/desktop.in"
+        "${CMAKE_CURRENT_LIST_DIR}/generated/${VPKEDIT_FLATPAK_ID}.desktop")
+install(FILES "${CMAKE_CURRENT_LIST_DIR}/generated/${VPKEDIT_FLATPAK_ID}.desktop"
         DESTINATION "share/applications/")
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
         DESTINATION "share/pixmaps/"
@@ -17,8 +17,8 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/branding/logo.png"
 # MIME type info
 set(VPKEDIT_MIME_TYPE_ICON_ID "${VPKEDIT_FLATPAK_ID}" CACHE INTERNAL "" FORCE)
 configure_file(
-        "${CMAKE_CURRENT_LIST_DIR}/linux/mime-type.xml.in"
-        "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/mime-type.xml")
-install(FILES "${CMAKE_CURRENT_LIST_DIR}/flatpak/generated/mime-type.xml"
+        "${CMAKE_CURRENT_LIST_DIR}/../linux/mime-type.xml.in"
+        "${CMAKE_CURRENT_LIST_DIR}/generated/mime-type.xml")
+install(FILES "${CMAKE_CURRENT_LIST_DIR}/generated/mime-type.xml"
         DESTINATION "share/mime/packages/"
         RENAME "${VPKEDIT_FLATPAK_ID}.xml")

--- a/src/installer/flatpak/desktop.in
+++ b/src/installer/flatpak/desktop.in
@@ -1,12 +1,10 @@
 [Desktop Entry]
-Version=${PROJECT_VERSION}
 Name=${PROJECT_NAME_PRETTY}
 Comment=${PROJECT_DESCRIPTION}
-Exec=/opt/${PROJECT_NAME}/${PROJECT_NAME} %f
+Exec=${PROJECT_NAME} %f
 Icon=${VPKEDIT_MIME_TYPE_ICON_ID}
 Terminal=false
 Type=Application
-Categories=Qt;Development;Utility;
+Categories=Game
 MimeType=application/x-vpkedit-007;application/x-vpkedit-bee-pack;application/x-vpkedit-bmz;application/x-vpkedit-bsp;application/x-vpkedit-fpk;application/x-vpkedit-fpx;application/x-vpkedit-gcf;application/x-vpkedit-gma;application/x-vpkedit-hog;application/x-vpkedit-ol;application/x-vpkedit-ore;application/x-vpkedit-pak;application/x-vpkedit-pck;application/x-vpkedit-vpk;application/x-vpkedit-vpp;application/x-dmx;application/x-mdl;image/x-ppl;image/x-tth;image/x-ttz;image/x-vtf;
 PrefersNonDefaultGPU=true
-X-KDE-RunOnDiscreteGpu=true

--- a/src/installer/flatpak/info.craftablescience.vpkedit.Devel.yaml
+++ b/src/installer/flatpak/info.craftablescience.vpkedit.Devel.yaml
@@ -18,6 +18,8 @@ modules:
       config-opts:
         - "-Wno-dev"
         - "-DCMAKE_BUILD_TYPE=Release"
+        - "-DVPKEDIT_USE_LTO=ON"
+        - "-DVPKEDIT_BUILD_INSTALLER=OFF"
         - "-DVPKEDIT_BUILD_FLATPAK=ON"
         - "-DVPKEDIT_FLATPAK_ID=info.craftablescience.vpkedit.Devel"
     builddir: true

--- a/src/installer/flatpak/info.craftablescience.vpkedit.Devel.yaml
+++ b/src/installer/flatpak/info.craftablescience.vpkedit.Devel.yaml
@@ -1,0 +1,26 @@
+"$schema": "https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json"
+id: info.craftablescience.vpkedit.Devel
+runtime: org.kde.Platform
+runtime-version: "6.8"
+sdk: org.kde.Sdk
+command: vpkedit
+finish-args:
+  - "--socket=wayland"
+  - "--socket=fallback-x11"
+  - "--filesystem=host"
+  - "--env=QT_QPA_PLATFORMTHEME=kde"
+modules:
+  - name: vpkedit
+    buildsystem: cmake-ninja
+    build-options:
+      build-args:
+        - "--share=network"
+      config-opts:
+        - "-Wno-dev"
+        - "-DCMAKE_BUILD_TYPE=Release"
+        - "-DVPKEDIT_BUILD_FLATPAK=ON"
+        - "-DVPKEDIT_FLATPAK_ID=info.craftablescience.vpkedit.Devel"
+    builddir: true
+    sources:
+      - type: dir
+        path: ../../..

--- a/src/installer/linux/mime-type.xml.in
+++ b/src/installer/linux/mime-type.xml.in
@@ -2,7 +2,7 @@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
     <mime-type type="application/x-vpkedit-007">
         <comment>007 - Nightfire Asset Pack</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>007</acronym>
         <expanded-acronym>Double-Oh Seven</expanded-acronym>
         <glob-deleteall/>
@@ -10,7 +10,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-bee-pack">
         <comment>BEE2.4 Package</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>BMZ</acronym>
         <expanded-acronym>Bonus Map Zip</expanded-acronym>
         <glob-deleteall/>
@@ -19,7 +19,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-bmz">
         <comment>Bonus Map Zip</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>BMZ</acronym>
         <expanded-acronym>Bonus Map Zip</expanded-acronym>
         <glob-deleteall/>
@@ -28,7 +28,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-bsp">
         <comment>Source Map File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>BSP</acronym>
         <expanded-acronym>Binary Space Partitioning</expanded-acronym>
         <glob-deleteall/>
@@ -37,7 +37,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-fpk">
         <comment>Tactical Intervention Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>FPK</acronym>
         <glob-deleteall/>
         <glob pattern="*.fpk"/>
@@ -45,7 +45,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-fpx">
         <comment>Tactical Intervention Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>FPX</acronym>
         <glob-deleteall/>
         <glob pattern="*.fpx"/>
@@ -53,7 +53,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-gcf">
         <comment>Game Cache File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>GCF</acronym>
         <expanded-acronym>Game Cache File</expanded-acronym>
         <glob-deleteall/>
@@ -62,7 +62,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-gma">
         <comment>Garry's Mod Addon</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>GMA</acronym>
         <expanded-acronym>Garry's Mod Addon</expanded-acronym>
         <glob-deleteall/>
@@ -71,7 +71,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-hog">
         <comment>Hog Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>HOG</acronym>
         <expanded-acronym>Hog Pack File</expanded-acronym>
         <glob-deleteall/>
@@ -80,7 +80,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-ol">
         <comment>Worldcraft Object Library</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>OL</acronym>
         <expanded-acronym>Worldcraft Object Library</expanded-acronym>
         <glob-deleteall/>
@@ -89,7 +89,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-ore">
         <comment>Narbacular Drop Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>ORE</acronym>
         <expanded-acronym>Narbacular Drop Pack File</expanded-acronym>
         <glob-deleteall/>
@@ -98,7 +98,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-pak">
         <comment>Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>PAK</acronym>
         <expanded-acronym>Pack File</expanded-acronym>
         <glob-deleteall/>
@@ -107,7 +107,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-pck">
         <comment>Godot Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>PCK</acronym>
         <expanded-acronym>Godot Pack File</expanded-acronym>
         <glob-deleteall/>
@@ -116,7 +116,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-vpk">
         <comment>Valve Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>VPK</acronym>
         <expanded-acronym>Valve Pack File</expanded-acronym>
         <glob-deleteall/>
@@ -125,7 +125,7 @@
     </mime-type>
     <mime-type type="application/x-vpkedit-vpp">
         <comment>Volition Pack File</comment>
-        <icon name="application-x-vpkedit"/>
+        <icon name="${VPKEDIT_MIME_TYPE_ICON_ID}"/>
         <acronym>VPP</acronym>
         <expanded-acronym>Volition Pack File</expanded-acronym>
         <glob-deleteall/>
@@ -150,9 +150,9 @@
         <glob pattern="*.mdl"/>
         <glob pattern="*.MDL"/>
     </mime-type>
-    <mime-type type="application/x-ppl">
+    <mime-type type="image/x-ppl">
         <comment>Prop Lightmap</comment>
-        <icon name="application-x-ppl"/>
+        <icon name="image-x-ppl"/>
         <acronym>PPL</acronym>
         <expanded-acronym>Prop Lightmap</expanded-acronym>
         <glob-deleteall/>


### PR DESCRIPTION
Discussion in #221 

What works:
* The Flatpak builds and runs properly, with KDE desktop theme
* I can load tf2_misc_000.vpk successfully inside and outside the sandbox

What currently does not work:
* Translations are currently not included in the Flatpak
* The portaled file picker is currently not used as it does not unveil the directory of the chosen file, which (not exclusively) vpkpp requires so it can open split files
* As a consequence the Flatpak currently asks for `--filesystem=host` which may weird out some users
* No AppStream data (description, url, etc)

Potentially controversial:
* The category of the desktop file has been changed to Game since Flatpak will complain if an entry is in multiple categories. This makes sense to me, because in the launcher the app is next to Steam. May not make sense to anyone else.

What was not tested:
* Windows
* Non-KDE Linux desktops (GNOME)
* Installation inside bare metal traditional Linux distro

What is currently missing but would be nice:
* GitHub actions for CI/nightly builds

I'd like to get the current work into the repo so that it can be built upon further

How to build and install:
* A Makefile is included in `src/installer/linux`, run `make flatpak` to build and `make flatpak-install` to install to your current system
* Various options are available:
  * `FLATPAK_INSTALLATION`: change this to `--user` if, for example, you are running inside a development container 
  * `FLATPAK_BUILDER_FLAGS`/`FLATPAK_INSTALL_FLAGS`: override flags passed to `flatpak-builder` and `flatpak install`
  * `FLATPAK_BUILDER_EXTRA_FLAGS`: as above, but in addition to the default flags