### PR TITLE
fix(gui): explicitly set GLSL profile in shaders

### DIFF
--- a/src/gui/res/shaders/mdl.vert
+++ b/src/gui/res/shaders/mdl.vert
@@ -1,4 +1,4 @@
-#version 150
+#version 150 core
 
 attribute vec3 vPos;
 attribute vec3 vNormal;

--- a/src/gui/res/shaders/mdl_shaded_textured.frag
+++ b/src/gui/res/shaders/mdl_shaded_textured.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 150 core
 
 uniform sampler2D uMeshTexture;
 uniform sampler2D uMatCapTexture;

--- a/src/gui/res/shaders/mdl_shaded_untextured.frag
+++ b/src/gui/res/shaders/mdl_shaded_untextured.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 150 core
 
 uniform sampler2D uMeshTexture;
 uniform sampler2D uMatCapTexture;

--- a/src/gui/res/shaders/mdl_unshaded_textured.frag
+++ b/src/gui/res/shaders/mdl_unshaded_textured.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 150 core
 
 uniform sampler2D uMeshTexture;
 uniform sampler2D uMatCapTexture;

--- a/src/gui/res/shaders/mdl_wireframe.frag
+++ b/src/gui/res/shaders/mdl_wireframe.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 150 core
 
 uniform sampler2D uMeshTexture;
 uniform sampler2D uMatCapTexture;


### PR DESCRIPTION
For some reason, current Nvidia drivers on Linux don't set a default OpenGL profile:
```
OpenGL version string: 4.6.0 NVIDIA 570.124.04
OpenGL shading language version string: 4.60 NVIDIA
OpenGL context flags: (none)
OpenGL profile mask: (none)
```
While other vendors do, an example from an AMD gpu:
```
OpenGL version string: 4.6 (Compatibility Profile) Mesa 25.0.1
OpenGL shading language version string: 4.60
OpenGL context flags: (none)
OpenGL profile mask: compatibility profile
```
This causes shaders used in model previews to fail compilation, making them not render with the logs containing the following lines, among others:
```
QOpenGLShader::compile(Vertex): 0(2) : error C0201: unsupported version 150
QOpenGLShader::compile(Fragment): 0(2) : error C0201: unsupported version 150
```

This PR works around this issue specifying the used GLSL profile in the shader sources. This is fully spec compliant, as can be seen [here](https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)#Version).