### PR TITLE
chore: adjust NixOS install instructions, add contributor

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -7,6 +7,7 @@
 - [Nbc66](https://github.com/Nbc66): added some extra info to the installation guide
 - [OzxyBox](https://github.com/ozxybox): WAD3 parser
 - [Rythyrix](https://github.com/Rythyrix): minor library bugfix
+- [SeraphimRP](https://github.com/SeraphimRP): Nixpkgs maintainer
 - [Tholp](https://github.com/Tholp1): major BSP stability improvements
 - [Trico Everfire](https://github.com/Trico-Everfire): open pack files based on Steam game install locations
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,7 +70,6 @@ as I don't use Arch Linux personally and don't know how that system works. (I us
 
 #### NixOS:
 
-VPKEdit is available from Nixpkgs thanks to [@Seraphim Pardee](https://github.com/SeraphimRP).
-To install to the default profile, run `nix-env -i vpkedit`. See the 
-[Nix documentation](https://nix-tutorial.gitlabpages.inria.fr/nix-tutorial/getting-started.html)
-for more information.
+VPKEdit is available from Nixpkgs unstable thanks to [@Seraphim Pardee](https://github.com/SeraphimRP).
+Add it to your system by placing `vpkedit` in the appropriate `environment.systemPackages = with pkgs; [];` section 
+in your Nix configuration. If you want to use it temporarily, run `nix-shell -p vpkedit` then `vpkedit` (for gui) or `vpkeditcli`.


### PR DESCRIPTION
Hey again!

Forgive me for this PR, but the instructions provided for NixOS use `nix-env`, which is largely considered an anti-pattern because it can cause a ton of conflicts between your system and what the Nix configuration declares. It's sort of a relic of the package manager from way back when and unfortunately it gets promoted as the de-facto way of installing packages by some places because it is the most analogous to something like `sudo {apt,dnf} install`.

https://stop-using-nix-env.privatevoid.net/ if you want to know the whole spiel :P

This provides the ideal instructions for installing the package, along with a note on having the package in a temporary shell for those ~~with commitment issues~~ who just need the programs for a moment.

Apologies, I should've provided more context in my email. I've had `nix-env` bite me in the past with something as simple as neovim, so just trying to avoid any future headache for people on Nix.

Thank you!