### PR TITLE
chore: VPKEdit now available in NixOS 25.05

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,6 @@ as I don't use Arch Linux personally and don't know how that system works. (I us
 
 #### NixOS:
 
-VPKEdit is available from Nixpkgs unstable thanks to [@Seraphim Pardee](https://github.com/SeraphimRP).
+VPKEdit is available in NixOS 25.05 and nixpkgs unstable thanks to [@Seraphim Pardee](https://github.com/SeraphimRP).
 Add it to your system by placing `vpkedit` in the appropriate `environment.systemPackages = with pkgs; [];` section 
 in your Nix configuration. If you want to use it temporarily, run `nix-shell -p vpkedit` then `vpkedit` (for gui) or `vpkeditcli`.


### PR DESCRIPTION
The latest stable release of NixOS, 25.05, includes VPKEdit in its available packages. Woot!

https://search.nixos.org/packages?channel=25.05&show=vpkedit&from=0&size=50&sort=relevance&type=packages&query=vpkedit