### PR TITLE
install: remove vtf mimetype

### DIFF
--- a/install/linux/mime-type.xml.in
+++ b/install/linux/mime-type.xml.in
@@ -177,14 +177,4 @@
         <glob pattern="*.ttz"/>
         <glob pattern="*.TTZ"/>
     </mime-type>
-    <mime-type type="image/x-vtf">
-        <comment>Valve Texture File</comment>
-        <icon name="image/x-vtf"/>
-        <acronym>VTF</acronym>
-        <expanded-acronym>Valve Texture File</expanded-acronym>
-        <glob-deleteall/>
-        <glob pattern="*.vtf"/>
-        <glob pattern="*.VTF"/>
-        <alias type="image/vnd.valve.source.texture"/>
-    </mime-type>
 </mime-info>


### PR DESCRIPTION
# Why
Now that `maretf` and `vpkedit` both list a mimetype for `x-image-vtf`, Dolphin does not show any icon if both programs are installed at the same time.

 - With patch:
 
<img width="1011" height="339" alt="Screenshot_20250812_224740" src="https://github.com/user-attachments/assets/8a45c20e-4bdd-4159-bf18-6e4e6eea350d" />

- Without patch:
<img width="844" height="346" alt="Screenshot_20250812_224925" src="https://github.com/user-attachments/assets/246144f1-4438-410e-b54d-4dde407b6f62" />

I think since `maretf` is the premier VTF tool, while vpkedit is able to just view them, I think `vpkedit` shouldn't have the `x-image-vtf` association.