### PR TITLE
feat(cli): Support for Reponse Files to the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vs/
 .vscode/
 CMakeSettings.json
+*.user
 
 # Project exclude paths
 build/

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,7 @@
 - [OzxyBox](https://github.com/ozxybox): WAD3 parser
 - [Rythyrix](https://github.com/Rythyrix): minor library bugfix
 - [SeraphimRP](https://github.com/SeraphimRP): Nixpkgs maintainer
+- [sour-dani](https://github.com/sour-dani): initial CLI response file implementation
 - [Tholp](https://github.com/Tholp1): major BSP stability improvements
 - [Trico Everfire](https://github.com/Trico-Everfire): open pack files based on Steam game install locations
 


### PR DESCRIPTION
As per #192 I have added support for users to pass a list of files stored in a text file that they want to be packed into a `.vpk`.

The implementation is based off the existing `pack` and `edit` functions.

Usage:
`vpkeditcli [packfile name] -r [list filename]`

Closes #192 