### PR TITLE
chore: remove nixpkgs maintainer, update username

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -8,7 +8,6 @@
 - [Nbc66](https://github.com/Nbc66): added some extra info to the installation guide
 - [OzxyBox](https://github.com/ozxybox): WAD3 parser
 - [Rythyrix](https://github.com/Rythyrix): minor library bugfix
-- [SeraphimRP](https://github.com/SeraphimRP): Nixpkgs maintainer
 - [sour-dani](https://github.com/sour-dani): initial CLI response file implementation
 - [Tholp](https://github.com/Tholp1): major BSP stability improvements
 - [Trico Everfire](https://github.com/Trico-Everfire): open pack files based on Steam game install locations

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,6 +92,6 @@ as I don't use Arch Linux personally and don't know how that system works. (I us
 
 #### NixOS:
 
-VPKEdit is available in NixOS 25.05 and nixpkgs unstable thanks to [@Seraphim Pardee](https://github.com/SeraphimRP).
+VPKEdit is available in NixOS 25.05 and nixpkgs unstable thanks to [@Seraphim Pardee](https://github.com/RdrSeraphim).
 Add it to your system by placing `vpkedit` in the appropriate `environment.systemPackages = with pkgs; [];` section 
 in your Nix configuration. If you want to use it temporarily, run `nix-shell -p vpkedit` then `vpkedit` (for gui) or `vpkeditcli`.


### PR DESCRIPTION
Given the red tape of managing the package and the inactivity from approvers, I'm no longer maintaining the Nix package and have moved back to Fedora. I'm happy to assist with RPM builds etc. if ever needed, but it looks like you've got that under control :)

I've kept the NixOS install line just because I'm not sure what the relative fate of the package itself will be. It's possible someone else could pick it up.

Thanks :)