### PR TITLE
fix(gui): scale with smooth mode

### DIFF
--- a/src/gui/previews/InfoPreview.cpp
+++ b/src/gui/previews/InfoPreview.cpp
@@ -11,7 +11,7 @@ InfoPreview::InfoPreview(const QPixmap& icon, const QString& text, QWidget* pare
 	layout->setContentsMargins(0,0,0,0);
 
 	this->image = new QLabel(this);
-	this->image->setPixmap(icon.scaled(64, 64, Qt::KeepAspectRatio));
+	this->image->setPixmap(icon.scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 	layout->addWidget(this->image, 0, Qt::AlignHCenter | Qt::AlignBottom);
 
 	this->error = new QLabel(this);
@@ -24,6 +24,6 @@ InfoPreview::InfoPreview(QWidget* parent)
 		: InfoPreview({":/icons/warning.png"}, "", parent) {}
 
 void InfoPreview::setData(const QPixmap& icon, const QString& text) {
-	this->image->setPixmap(icon.scaled(64, 64, Qt::KeepAspectRatio));
+	this->image->setPixmap(icon.scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 	this->error->setText(text);
 }


### PR DESCRIPTION
This fixes the empty logo icon scaling improperly and having artifacts

Before:
<img width="922" height="560" src="https://github.com/user-attachments/assets/47e60f51-9f13-4e5f-87f4-c0c3d1f704af" />

After:
<img width="922" height="560" src="https://github.com/user-attachments/assets/3f2b4c5e-cb21-4c04-a2bf-07f0e5db134b" />

Others things that use InfoPreview should also be smoother but i'm not quite sure