### PR TITLE
Add additional text file extensions (mostly for IdTech 3 and GoldSrc)

### DIFF
--- a/src/gui/previews/TextPreview.h
+++ b/src/gui/previews/TextPreview.h
@@ -77,24 +77,28 @@ class TextPreview : public QWidget {
 public:
 	// Reminder if you add a format that should be highlighted to change that list too!
 	static inline const QStringList EXTENSIONS {
-		".txt", ".md", // Text
-		".nut", ".gnut", ".lua", ".gm", ".py", ".js", ".ts", // Scripting
+		".txt", ".md", ".log", // Text
+		".nut", ".gnut", ".lua", ".gm", ".py", ".js", ".ts", ".script", // Scripting
 		".map", ".vmf", ".vmm", ".vmx", ".vmt", // Maps
 		".vcd", ".fgd", ".qc", ".qci", ".qcx", ".smd", // Models / FGD
 		".kv", ".kv3", ".res", ".vdf", ".acf", ".bns", // KeyValues
-		".vbsp", ".rad", ".gam", ".gi", ".rc", ".lst", // Valve
-		".cfg", ".ini", ".yml", ".yaml", ".toml", ".json", // Config
+		".vbsp", ".rad", ".gam", ".gi", ".rc", ".lst", ".sc", // Valve
+		".cfg", ".config", ".ini", ".yml", ".yaml", ".toml", ".json", // Config
 		".html", ".htm", ".xml", ".css", ".scss", ".sass", // Web
 		"authors", "credits", "license", "readme", // Metadata
 		".gitignore", ".gitattributes", ".gitmodules", // Git
 		".gd", ".gdshader", ".tscn", ".tres", ".import", ".remap", // Godot
 		".zpc", ".zpdata", // Zombie Panic Survival
+		".mat", // Condition Zero Deleted Scenes, Quake II Remaster
 		".pop", // Team Fortress 2
 		".edt", // Synergy
 		".set", // Titanfall & Apex Legends
 		".scr", ".dlg", ".lip", ".vfe", // Vampire: The Masquerade - Bloodlines
 		".tbl", // Red Faction
 		".vint_doc", ".vint_proj", // Saints Row 2
+		".shader", ".skin", ".arena", // IdTech 3
+		".objdata", // Wolfenstein: Enemy Territory
+		".icarus", ".efx" // Raven Software IdTech 3 games
 	};
 
 	TextPreview(FileViewer* fileViewer_, Window* window_, QWidget* parent = nullptr);


### PR DESCRIPTION
Added formats are as such (mostly for making PK3s easier to navigate):
* .log - self explanatory; one is found in Quake III's pak0.pk3.
* .config - used in Quake 3 for defining multiplayer gamemode cvars (same syntax as cfg and rc)
* .sc - GoldSrc weapon scripts (unused in vanilla)
* .mat - Condition Zero Deleted Scenes particle effects, Quake II Remaster footstep sfx, Fairytale Busters VMT (unrelated formats, but all plain text)
* .shader - IdTech 3 materials
* .skin - IdTech 3 skin remaps (similar syntax to CSV)
* .arena - IdTech 3 map metadata
* .script - RtCW and WolfET scripts (probably also used elsewhere)
* .objdata - WolfET per-map cvars (same syntax as cfg and rc)
* .icarus - Raven software uncompiled script (various IdTech 3 games)
* .efx - Raven software particle effect (various IdTech 3 games)

Some of the formats are similar to KeyValues, I guess, but I didn't touch `keyValuesLikeFormats` since I don't know what qualifies there (apparently .map doesn't?).
Draft because I don't know if modifying `SingleFile.h` is necessary.